### PR TITLE
Standalone library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,14 +33,6 @@ if ("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
   message (FATAL_ERROR "Remove the created \"CMakeCache.txt\" file and the \"CMakeFiles\" directory, then create a build directory and call \"${CMAKE_COMMAND} <path to the sources>\".")
 endif ("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
 
-# Finds all files with a given extension
-macro (append_files files ext)
-  foreach (dir ${ARGN})
-    file (GLOB _files "${dir}/*.${ext}")
-    list (APPEND ${files} ${_files})
-  endforeach (dir)
-endmacro (append_files)
-
 include(GNUInstallDirs)
 add_subdirectory (libWetHair)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/assets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,12 @@ set(CMAKE_CXX_STANDARD          11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS        OFF)
 
+option(LIBWETHAIR_BUILD_CORE "Enable the core library, it is ON by default. Use BUILD_SHARED_LIBS to control the type of the library" ON)
+option(LIBWETHAIR_BUILD_APP "Enable the libWetHair executable, it is ON by default." ON)
+option(LIBWETHAIR_INSTALL_ASSETS "Install the assests, it is ON by default." ON)
+
+include(GNUInstallDirs)
+
 if (NOT CMAKE_INSTALL_PREFIX)
   set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install")
 endif (NOT CMAKE_INSTALL_PREFIX)
@@ -33,7 +39,10 @@ if ("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
   message (FATAL_ERROR "Remove the created \"CMakeCache.txt\" file and the \"CMakeFiles\" directory, then create a build directory and call \"${CMAKE_COMMAND} <path to the sources>\".")
 endif ("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
 
-include(GNUInstallDirs)
+
 add_subdirectory (libWetHair)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/assets
-  DESTINATION ${CMAKE_INSTALL_DATADIR}/libWetHair)
+
+if (LIBWETHAIR_INSTALL_ASSETS)
+  install(DIRECTORY ${CMAKE_SOURCE_DIR}/assets
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/libWetHair)
+endif (LIBWETHAIR_INSTALL_ASSESTS)

--- a/libWetHair/CMakeLists.txt
+++ b/libWetHair/CMakeLists.txt
@@ -1,9 +1,5 @@
 # libWetHair Executable
 
-append_files (Headers "h" . App Core Core/DER Core/DER/Forces Core/DER/Dependencies Core/pcgsolver)
-append_files (Sources "cpp" . App Core Core/DER Core/DER/Forces Core/DER/Dependencies Core/pcgsolver)
-append_files (Sources "c" . App Core Core/DER Core/DER/Forces Core/DER/Dependencies Core/pcgsolver)
-
 # Find dependencies
 find_package (ANTTWEAKBAR REQUIRED)
 find_package (Eigen3 REQUIRED CONFIG)
@@ -17,9 +13,64 @@ find_package (TCLAP REQUIRED)
 set (THREADS_PREFER_PTHREAD_FLAG ON)
 find_package (Threads REQUIRED)
 
-add_executable (libWetHair ${Headers} ${Templates} ${Sources})
+add_executable (libWetHair
+  "App/Camera.cpp"
+  "App/ParticleSimulation.cpp"
+  "App/RenderingUtilities.cpp"
+  "App/StringUtilities.cpp"
+  "App/TwoDSceneRenderer.cpp"
+  "App/TwoDSceneSerializer.cpp"
+  "App/TwoDSceneXMLParser.cpp"
+  "App/TwoDimensionalDisplayController.cpp"
+  "App/YImage.cpp"
+  "App/main.cpp"
+  "App/openglutils.cpp"
+
+  "Core/DER/Dependencies/DegreesOfFreedom.cpp"
+  "Core/DER/Dependencies/ElasticStrandUtils.cpp"
+  "Core/DER/Dependencies/Kappas.cpp"
+  "Core/DER/Dependencies/MaterialFrames.cpp"
+  "Core/DER/Dependencies/ReferenceFrames.cpp"
+  "Core/DER/Dependencies/Twists.cpp"
+  "Core/DER/Forces/BendingForce.cpp"
+  "Core/DER/Forces/StretchingForce.cpp"
+  "Core/DER/Forces/TwistingForce.cpp"
+  "Core/DER/StrandForce.cpp"
+  "Core/CTCD.cpp"
+  "Core/Capsule.cpp"
+  "Core/CohesionTableGen.cpp"
+  "Core/CompliantImplicitEuler.cpp"
+  "Core/CylindricalShallowFlow.cpp"
+  "Core/DragDampingForce.cpp"
+  "Core/FluidDragForce.cpp"
+  "Core/Force.cpp"
+  "Core/GeometricLevelGen.cpp"
+  "Core/HairFlow.cpp"
+  "Core/Icosphere.cpp"
+  "Core/LevelSetForce.cpp"
+  "Core/LinearBendingForce.cpp"
+  "Core/LinearSpringForce.cpp"
+  "Core/MathUtilities.cpp"
+  "Core/PolygonalCohesion.cpp"
+  "Core/SceneStepper.cpp"
+  "Core/SimpleGravityForce.cpp"
+  "Core/SpringForce.cpp"
+  "Core/StrandCompliantEuler.cpp"
+  "Core/StrandCompliantManager.cpp"
+  "Core/TimingUtilities.cpp"
+  "Core/TwoDScene.cpp"
+  "Core/WetHairCore.cpp"
+  "Core/fluidsim.cpp"
+  "Core/fluidsim2D.cpp"
+  "Core/fluidsim3D.cpp"
+  "Core/liangbarsky.cpp"
+  "Core/sorter.cpp"
+  "Core/viscosity3d.cpp"
+  "Core/volume_fractions.cpp"
+  )
+
 target_include_directories(libWetHair PRIVATE "Core")
-target_link_libraries(libWetHair PRIVATE ${LIBWETHAIR_LIBRARIES}
+target_link_libraries(libWetHair PRIVATE
   ANTTWEAKBAR::AntTweakBar
   Eigen3::Eigen
   FreeGLUT::freeglut

--- a/libWetHair/CMakeLists.txt
+++ b/libWetHair/CMakeLists.txt
@@ -13,19 +13,7 @@ find_package (TCLAP REQUIRED)
 set (THREADS_PREFER_PTHREAD_FLAG ON)
 find_package (Threads REQUIRED)
 
-add_executable (libWetHair
-  "App/Camera.cpp"
-  "App/ParticleSimulation.cpp"
-  "App/RenderingUtilities.cpp"
-  "App/StringUtilities.cpp"
-  "App/TwoDSceneRenderer.cpp"
-  "App/TwoDSceneSerializer.cpp"
-  "App/TwoDSceneXMLParser.cpp"
-  "App/TwoDimensionalDisplayController.cpp"
-  "App/YImage.cpp"
-  "App/main.cpp"
-  "App/openglutils.cpp"
-
+add_library (WetHairCore
   "Core/DER/Dependencies/DegreesOfFreedom.cpp"
   "Core/DER/Dependencies/ElasticStrandUtils.cpp"
   "Core/DER/Dependencies/Kappas.cpp"
@@ -66,11 +54,33 @@ add_executable (libWetHair
   "Core/liangbarsky.cpp"
   "Core/sorter.cpp"
   "Core/viscosity3d.cpp"
-  "Core/volume_fractions.cpp"
-  )
+  "Core/volume_fractions.cpp")
+add_library(libWetHair::WetHairCore ALIAS WetHairCore)
+
+target_link_libraries(WetHairCore
+  PUBLIC
+  Eigen3::Eigen
+  TBB::tbb
+  PRIVATE
+  Threads::Threads
+)
+
+add_executable (libWetHair
+  "App/Camera.cpp"
+  "App/ParticleSimulation.cpp"
+  "App/RenderingUtilities.cpp"
+  "App/StringUtilities.cpp"
+  "App/TwoDSceneRenderer.cpp"
+  "App/TwoDSceneSerializer.cpp"
+  "App/TwoDSceneXMLParser.cpp"
+  "App/TwoDimensionalDisplayController.cpp"
+  "App/YImage.cpp"
+  "App/main.cpp"
+  "App/openglutils.cpp")
 
 target_include_directories(libWetHair PRIVATE "Core")
 target_link_libraries(libWetHair PRIVATE
+  libWetHair::WetHairCore
   ANTTWEAKBAR::AntTweakBar
   Eigen3::Eigen
   FreeGLUT::freeglut
@@ -78,8 +88,12 @@ target_link_libraries(libWetHair PRIVATE
   OpenGL::GLU
   PNG::PNG
   RapidXML::RapidXML
-  TBB::tbb
-  TCLAP::tclap
-  Threads::Threads)
+  TCLAP::tclap)
 
-install(TARGETS libWetHair)
+install(TARGETS libWetHair WetHairCore)
+
+# Install headers
+install(DIRECTORY Core/
+  DESTINATION include/libWetHair
+  FILES_MATCHING
+  PATTERN *.h)

--- a/libWetHair/CMakeLists.txt
+++ b/libWetHair/CMakeLists.txt
@@ -1,114 +1,123 @@
-# libWetHair Executable
 
-# Find dependencies
-find_package (ANTTWEAKBAR REQUIRED)
-find_package (Eigen3 REQUIRED CONFIG)
-find_package (FreeGLUT REQUIRED CONFIG)
-find_package (GLEW REQUIRED)
-find_package (OpenGL REQUIRED)
-find_package (PNG REQUIRED)
-find_package (RapidXML REQUIRED)
-find_package (TBB REQUIRED CONFIG)
-find_package (TCLAP REQUIRED)
-set (THREADS_PREFER_PTHREAD_FLAG ON)
-find_package (Threads REQUIRED)
+if (LIBWETHAIR_BUILD_CORE)
+  # Find dependencies
+  find_package (Eigen3 REQUIRED CONFIG)
+  find_package (TBB REQUIRED CONFIG)
+  set (THREADS_PREFER_PTHREAD_FLAG ON)
+  find_package (Threads REQUIRED)
 
-add_library (WetHairCore
-  "Core/DER/Dependencies/DegreesOfFreedom.cpp"
-  "Core/DER/Dependencies/ElasticStrandUtils.cpp"
-  "Core/DER/Dependencies/Kappas.cpp"
-  "Core/DER/Dependencies/MaterialFrames.cpp"
-  "Core/DER/Dependencies/ReferenceFrames.cpp"
-  "Core/DER/Dependencies/Twists.cpp"
-  "Core/DER/Forces/BendingForce.cpp"
-  "Core/DER/Forces/StretchingForce.cpp"
-  "Core/DER/Forces/TwistingForce.cpp"
-  "Core/DER/StrandForce.cpp"
-  "Core/CTCD.cpp"
-  "Core/Capsule.cpp"
-  "Core/CohesionTableGen.cpp"
-  "Core/CompliantImplicitEuler.cpp"
-  "Core/CylindricalShallowFlow.cpp"
-  "Core/DragDampingForce.cpp"
-  "Core/FluidDragForce.cpp"
-  "Core/Force.cpp"
-  "Core/GeometricLevelGen.cpp"
-  "Core/HairFlow.cpp"
-  "Core/Icosphere.cpp"
-  "Core/LevelSetForce.cpp"
-  "Core/LinearBendingForce.cpp"
-  "Core/LinearSpringForce.cpp"
-  "Core/MathUtilities.cpp"
-  "Core/PolygonalCohesion.cpp"
-  "Core/SceneStepper.cpp"
-  "Core/SimpleGravityForce.cpp"
-  "Core/SpringForce.cpp"
-  "Core/StrandCompliantEuler.cpp"
-  "Core/StrandCompliantManager.cpp"
-  "Core/TimingUtilities.cpp"
-  "Core/TwoDScene.cpp"
-  "Core/WetHairCore.cpp"
-  "Core/fluidsim.cpp"
-  "Core/fluidsim2D.cpp"
-  "Core/fluidsim3D.cpp"
-  "Core/liangbarsky.cpp"
-  "Core/sorter.cpp"
-  "Core/viscosity3d.cpp"
-  "Core/volume_fractions.cpp")
-add_library(libWetHair::WetHairCore ALIAS WetHairCore)
+  add_library (WetHairCore
+    "Core/DER/Dependencies/DegreesOfFreedom.cpp"
+    "Core/DER/Dependencies/ElasticStrandUtils.cpp"
+    "Core/DER/Dependencies/Kappas.cpp"
+    "Core/DER/Dependencies/MaterialFrames.cpp"
+    "Core/DER/Dependencies/ReferenceFrames.cpp"
+    "Core/DER/Dependencies/Twists.cpp"
+    "Core/DER/Forces/BendingForce.cpp"
+    "Core/DER/Forces/StretchingForce.cpp"
+    "Core/DER/Forces/TwistingForce.cpp"
+    "Core/DER/StrandForce.cpp"
+    "Core/CTCD.cpp"
+    "Core/Capsule.cpp"
+    "Core/CohesionTableGen.cpp"
+    "Core/CompliantImplicitEuler.cpp"
+    "Core/CylindricalShallowFlow.cpp"
+    "Core/DragDampingForce.cpp"
+    "Core/FluidDragForce.cpp"
+    "Core/Force.cpp"
+    "Core/GeometricLevelGen.cpp"
+    "Core/HairFlow.cpp"
+    "Core/Icosphere.cpp"
+    "Core/LevelSetForce.cpp"
+    "Core/LinearBendingForce.cpp"
+    "Core/LinearSpringForce.cpp"
+    "Core/MathUtilities.cpp"
+    "Core/PolygonalCohesion.cpp"
+    "Core/SceneStepper.cpp"
+    "Core/SimpleGravityForce.cpp"
+    "Core/SpringForce.cpp"
+    "Core/StrandCompliantEuler.cpp"
+    "Core/StrandCompliantManager.cpp"
+    "Core/TimingUtilities.cpp"
+    "Core/TwoDScene.cpp"
+    "Core/WetHairCore.cpp"
+    "Core/fluidsim.cpp"
+    "Core/fluidsim2D.cpp"
+    "Core/fluidsim3D.cpp"
+    "Core/liangbarsky.cpp"
+    "Core/sorter.cpp"
+    "Core/viscosity3d.cpp"
+    "Core/volume_fractions.cpp")
+  add_library(libWetHair::WetHairCore ALIAS WetHairCore)
 
-target_link_libraries(WetHairCore
-  PUBLIC
-  Eigen3::Eigen
-  TBB::tbb
-  PRIVATE
-  Threads::Threads)
+  target_link_libraries(WetHairCore
+    PUBLIC
+    Eigen3::Eigen
+    TBB::tbb
+    PRIVATE
+    Threads::Threads)
 
-target_include_directories(WetHairCore INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Core>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libWetHair>)
+  target_include_directories(WetHairCore INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Core>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libWetHair>)
 
-add_executable (libWetHair
-  "App/Camera.cpp"
-  "App/ParticleSimulation.cpp"
-  "App/RenderingUtilities.cpp"
-  "App/StringUtilities.cpp"
-  "App/TwoDSceneRenderer.cpp"
-  "App/TwoDSceneSerializer.cpp"
-  "App/TwoDSceneXMLParser.cpp"
-  "App/TwoDimensionalDisplayController.cpp"
-  "App/YImage.cpp"
-  "App/main.cpp"
-  "App/openglutils.cpp")
+  install(TARGETS WetHairCore
+    EXPORT WetHairCore)
 
-target_link_libraries(libWetHair PRIVATE
-  libWetHair::WetHairCore
-  ANTTWEAKBAR::AntTweakBar
-  Eigen3::Eigen
-  FreeGLUT::freeglut
-  GLEW::glew
-  OpenGL::GLU
-  PNG::PNG
-  RapidXML::RapidXML
-  TCLAP::tclap)
+  install(EXPORT WetHairCore
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libWetHair"
+    NAMESPACE libWetHair::
+    FILE libWetHair_WetHairCore.cmake
+    COMPONENT WetHairCore)
 
-install(TARGETS libWetHair)
+  install(FILES libWetHairConfig.cmake
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libWetHair")
 
-install(TARGETS WetHairCore
-  EXPORT WetHairCore)
+  # Install headers
+  install(DIRECTORY Core/
+    DESTINATION include/libWetHair
+    FILES_MATCHING
+    PATTERN *.h)
 
-install(EXPORT WetHairCore
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libWetHair"
-  NAMESPACE libWetHair::
-  FILE libWetHair_WetHairCore.cmake
-  COMPONENT WetHairCore)
+endif (LIBWETHAIR_BUILD_CORE)
 
-install(FILES libWetHairConfig.cmake
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libWetHair")
+if (LIBWETHAIR_BUILD_APP)
+  # Find dependencies
+  if (NOT TARGET libWetHair::WetHairCore)
+    find_package (libWetHair REQUIRED CONFIG)
+  endif (NOT TARGET libWetHair::WetHairCore)
+  find_package (ANTTWEAKBAR REQUIRED)
+  find_package (Eigen3 REQUIRED CONFIG)
+  find_package (FreeGLUT REQUIRED CONFIG)
+  find_package (GLEW REQUIRED)
+  find_package (OpenGL REQUIRED)
+  find_package (PNG REQUIRED)
+  find_package (RapidXML REQUIRED)
+  find_package (TCLAP REQUIRED)
 
-# Install headers
-install(DIRECTORY Core/
-  DESTINATION include/libWetHair
-  FILES_MATCHING
-  PATTERN *.h)
+  add_executable (libWetHair
+    "App/Camera.cpp"
+    "App/ParticleSimulation.cpp"
+    "App/RenderingUtilities.cpp"
+    "App/StringUtilities.cpp"
+    "App/TwoDSceneRenderer.cpp"
+    "App/TwoDSceneSerializer.cpp"
+    "App/TwoDSceneXMLParser.cpp"
+    "App/TwoDimensionalDisplayController.cpp"
+    "App/YImage.cpp"
+    "App/main.cpp"
+    "App/openglutils.cpp")
 
+  target_link_libraries(libWetHair PRIVATE
+    libWetHair::WetHairCore
+    ANTTWEAKBAR::AntTweakBar
+    Eigen3::Eigen
+    FreeGLUT::freeglut
+    GLEW::glew
+    OpenGL::GLU
+    PNG::PNG
+    RapidXML::RapidXML
+    TCLAP::tclap)
+
+  install(TARGETS libWetHair)
+endif (LIBWETHAIR_BUILD_APP)

--- a/libWetHair/CMakeLists.txt
+++ b/libWetHair/CMakeLists.txt
@@ -90,10 +90,23 @@ target_link_libraries(libWetHair PRIVATE
   RapidXML::RapidXML
   TCLAP::tclap)
 
-install(TARGETS libWetHair WetHairCore)
+install(TARGETS libWetHair)
+
+install(TARGETS WetHairCore
+  EXPORT WetHairCore)
+
+install(EXPORT WetHairCore
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libWetHair"
+  NAMESPACE libWetHair::
+  FILE libWetHair_WetHairCore.cmake
+  COMPONENT WetHairCore)
+
+install(FILES libWetHairConfig.cmake
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libWetHair")
 
 # Install headers
 install(DIRECTORY Core/
   DESTINATION include/libWetHair
   FILES_MATCHING
   PATTERN *.h)
+

--- a/libWetHair/CMakeLists.txt
+++ b/libWetHair/CMakeLists.txt
@@ -62,8 +62,11 @@ target_link_libraries(WetHairCore
   Eigen3::Eigen
   TBB::tbb
   PRIVATE
-  Threads::Threads
-)
+  Threads::Threads)
+
+target_include_directories(WetHairCore INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Core>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/libWetHair>)
 
 add_executable (libWetHair
   "App/Camera.cpp"
@@ -78,7 +81,6 @@ add_executable (libWetHair
   "App/main.cpp"
   "App/openglutils.cpp")
 
-target_include_directories(libWetHair PRIVATE "Core")
 target_link_libraries(libWetHair PRIVATE
   libWetHair::WetHairCore
   ANTTWEAKBAR::AntTweakBar

--- a/libWetHair/libWetHairConfig.cmake
+++ b/libWetHair/libWetHairConfig.cmake
@@ -1,0 +1,11 @@
+
+
+if (NOT TARGET libWetHair::WetHairCore)
+  # Find dependencies for WetHairCore
+  include (CMakeFindDependencyMacro)
+  find_dependency (Eigen3)
+  find_dependency (TBB)
+  find_dependency (Threads)
+
+  include (${CMAKE_CURRENT_LIST_DIR}/libWetHair_WetHairCore.cmake)
+endif ()


### PR DESCRIPTION
Updated the CMake files to build the `Core` sources as a separate library, which then `App` link against.

The library uses the default type set by CMake, on linux this is static and I assume this is the same for the other platforms. You can change this by including `-DBUILD_SHARED_LIBS=YES` on the `cmake` command line.

I also added three options:

- LIBWETHAIR_BUILD_CORE: boolean, to specify to build the library or not.
- LIBWETHAIR_BUILD_APP: boolean, to specify to build the app or not.
- LIBWETHAIR_INSTALL_ASSETS: boolean, to specify to install the assets or not

This allows you to select what you need. In mine use case it allows me to package up the library and app separately, reducing the dependencies for the library.