### PR TITLE
Make Threads::Threads public for WetHairCore in the CMakeLists.txt

### DIFF
--- a/libWetHair/CMakeLists.txt
+++ b/libWetHair/CMakeLists.txt
@@ -54,7 +54,6 @@ if (LIBWETHAIR_BUILD_CORE)
     PUBLIC
     Eigen3::Eigen
     TBB::tbb
-    PRIVATE
     Threads::Threads)
 
   target_include_directories(WetHairCore INTERFACE


### PR DESCRIPTION
Otherwise it will cause a compilation error when the WetHairCore is built as a shared library.

I missed this the first time (I forgot to build this with `-DBUILD_SHARED_LIBS=YES`) as when building that statically, cmake will propagate _all_ dependencies to the dependents. Given that a static library does not have concept of NEEDED as a shared one does.

*NOTE* This will cause a merge conflicts with #10.