### PR TITLE
Add cmake option LIBWETHAIR_FIND_DEPENDENCIES

### DIFF
--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -2,6 +2,7 @@
 if (NOT TARGET libWetHair::WetHairCore)
   find_package (libWetHair REQUIRED CONFIG)
 endif (NOT TARGET libWetHair::WetHairCore)
+include (eigen)
 include (glfw)
 include (glew)
 include (anttweakbar)

--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable (libWetHair
 target_link_libraries(libWetHair PRIVATE
   libWetHair::WetHairCore
   glfw::glfw
-  anttweakbar::anttweakbar
+  AntTweakBar::AntTweakBar
   Eigen3::Eigen
   GLEW::glew
   OpenGL::GLU

--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(libWetHair PRIVATE
   glfw::glfw
   anttweakbar::anttweakbar
   Eigen3::Eigen
-  glew::glew
+  GLEW::glew
   OpenGL::GLU
   rapidxml::rapidxml
   tclap::tclap

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_EXTENSIONS        OFF)
 option(LIBWETHAIR_BUILD_CORE "Enable the core library, it is ON by default. Use BUILD_SHARED_LIBS to control the type of the library" ON)
 option(LIBWETHAIR_BUILD_APP "Enable the libWetHair executable, it is ON by default." ON)
 option(LIBWETHAIR_INSTALL_ASSETS "Install the assests, it is ON by default." ON)
+option(LIBWETHAIR_FIND_DEPENDENCIES "Find dependencies instead of downloading them" OFF)
 
 include(GNUInstallDirs)
 

--- a/cmake/Findrapidxml.cmake
+++ b/cmake/Findrapidxml.cmake
@@ -1,0 +1,25 @@
+#
+# This file is part of the libWetHair open source project
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright 2017 Breannan Smith (smith@cs.columbia.edu)
+# Copyright 2017 Yun (Raymond) Fei
+# Copyright 2022 Fredrik Salomonsson
+#
+
+find_path(RAPIDXML_INCLUDE_DIR rapidxml.hpp
+    PATHS
+    ${RAPIDXML_ROOT}
+    PATH_SUFFIXES
+    include
+    include/rapidxml)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(rapidxml DEFAULT_MSG RAPIDXML_INCLUDE_DIR)
+mark_as_advanced(RAPIDXML_INCLUDE_DIR)
+
+add_library(rapidxml::rapidxml INTERFACE IMPORTED)
+target_include_directories(rapidxml::rapidxml INTERFACE "${RAPIDXML_INCLUDE_DIR}")

--- a/cmake/Findstb.cmake
+++ b/cmake/Findstb.cmake
@@ -1,0 +1,21 @@
+#
+# This file is part of the libWetHair open source project
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright 2022 Fredrik Salomonsson
+#
+find_path(STB_IMAGE_WRITE_INCLUDE_DIR stb_image_write.h
+    PATHS
+    ${STB_IMAGE_WRITE_ROOT}
+    PATH_SUFFIXES
+    include)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(stb DEFAULT_MSG STB_IMAGE_WRITE_INCLUDE_DIR)
+mark_as_advanced(STB_IMAGE_WRITE_INCLUDE_DIR)
+
+add_library(stb::stb INTERFACE IMPORTED)
+target_include_directories(stb::stb INTERFACE "${STB_IMAGE_WRITE_INCLUDE_DIR}")

--- a/cmake/Findtclap.cmake
+++ b/cmake/Findtclap.cmake
@@ -1,0 +1,13 @@
+#
+# This file is part of the libWetHair open source project
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright 2017 Yun (Raymond) Fei
+# Copyright 2022 Fredrik Salomonsson
+#
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(tclap REQUIRED IMPORTED_TARGET tclap)
+add_library(tclap::tclap ALIAS PkgConfig::tclap)

--- a/cmake/anttweakbar.cmake
+++ b/cmake/anttweakbar.cmake
@@ -26,6 +26,6 @@ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "anttweakbar")
 set(ATB_BUILD_EXAMPLES OFF CACHE BOOL "")
 FetchContent_MakeAvailable(anttweakbar)
 
-add_library(anttweakbar::anttweakbar ALIAS AntTweakBar)
+add_library(AntTweakBar::AntTweakBar ALIAS AntTweakBar)
 
 set_target_properties(AntTweakBar PROPERTIES FOLDER third_party)

--- a/cmake/anttweakbar.cmake
+++ b/cmake/anttweakbar.cmake
@@ -11,6 +11,13 @@
 
 if(TARGET anttweakbar::anttweakbar)
     return()
+elseif(LIBWETHAIR_FIND_DEPENDENCIES)
+    find_package(AntTweakBar REQUIRED CONFIG)
+    # The AntTweakBar config does not namespace their target
+    if(NOT TARGET AntTweakBar::AntTweakBar)
+        add_library(AntTweakBar::AntTweakBar ALIAS AntTweakBar)
+    endif()
+    return()
 endif()
 
 message(STATUS "Third-party (external): creating target 'anttweakbar::anttweakbar'")

--- a/cmake/eigen.cmake
+++ b/cmake/eigen.cmake
@@ -11,6 +11,9 @@
 #
 if(TARGET Eigen3::Eigen)
     return()
+elseif(LIBWETHAIR_FIND_DEPENDENCIES)
+    find_package(Eigen3 REQUIRED CONFIG)
+    return()
 endif()
 
 option(EIGEN_WITH_MKL "Use Eigen with MKL" OFF)

--- a/cmake/glew.cmake
+++ b/cmake/glew.cmake
@@ -9,11 +9,11 @@
 # Changxi Zheng, and Eitan Grinspun
 # 
 
-if(TARGET glew::glew)
+if(TARGET GLEW::glew)
     return()
 endif()
 
-message(STATUS "Third-party (external): creating target 'glew::glew'")
+message(STATUS "Third-party (external): creating target 'GLEW::glew'")
 
 include(FetchContent)
 FetchContent_Declare(
@@ -26,6 +26,6 @@ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "glew")
 set(glew-cmake_BUILD_SHARED OFF CACHE BOOL "")
 FetchContent_MakeAvailable(glew)
 
-add_library(glew::glew ALIAS libglew_static)
+add_library(GLEW::glew ALIAS libglew_static)
 
 set_target_properties(libglew_static PROPERTIES FOLDER third_party)

--- a/cmake/glew.cmake
+++ b/cmake/glew.cmake
@@ -11,6 +11,9 @@
 
 if(TARGET GLEW::glew)
     return()
+elseif(LIBWETHAIR_FIND_DEPENDENCIES)
+    find_package(GLEW REQUIRED)
+    return()
 endif()
 
 message(STATUS "Third-party (external): creating target 'GLEW::glew'")

--- a/cmake/glfw.cmake
+++ b/cmake/glfw.cmake
@@ -11,6 +11,13 @@
 #
 if(TARGET glfw::glfw)
     return()
+elseif(LIBWETHAIR_FIND_DEPENDENCIES)
+    find_package(glfw3 REQUIRED CONFIG)
+    # The glfw3 config does not namespace their target
+    if(NOT TARGET glfw::glfw)
+        add_library(glfw::glfw ALIAS glfw)
+    endif()
+    return()
 endif()
 
 if(EMSCRIPTEN)

--- a/cmake/onetbb.cmake
+++ b/cmake/onetbb.cmake
@@ -11,6 +11,9 @@
 #
 if(TARGET TBB::tbb)
     return()
+elseif(LIBWETHAIR_FIND_DEPENDENCIES)
+    find_package(TBB REQUIRED CONFIG)
+    return()
 endif()
 
 message(STATUS "Third-party (external): creating target 'TBB::tbb' (OneTBB)")

--- a/cmake/rapidxml.cmake
+++ b/cmake/rapidxml.cmake
@@ -11,6 +11,9 @@
 
 if(TARGET rapidxml::rapidxml)
     return()
+elseif(LIBWETHAIR_FIND_DEPENDENCIES)
+    find_package(rapidxml REQUIRED)
+    return()
 endif()
 
 message(STATUS "Third-party (external): creating target 'rapidxml::rapidxml'")

--- a/cmake/stb.cmake
+++ b/cmake/stb.cmake
@@ -11,6 +11,9 @@
 #
 if(TARGET stb::stb)
     return()
+elseif(LIBWETHAIR_FIND_DEPENDENCIES)
+    find_package(stb REQUIRED)
+    return()
 endif()
 
 message(STATUS "Third-party (external): creating target 'stb::stb'")

--- a/cmake/tclap.cmake
+++ b/cmake/tclap.cmake
@@ -11,6 +11,9 @@
 
 if(TARGET tclap::tclap)
     return()
+elseif(LIBWETHAIR_FIND_DEPENDENCIES)
+    find_package(tclap REQUIRED)
+    return()
 endif()
 
 message(STATUS "Third-party (external): creating target 'tclap::tclap'")


### PR DESCRIPTION
Which allows to find dependencies instead of downloading them. This is off by default.

Downloading and vendoring dependencies does not fit well with package managers on linux. The dependency graph is hidden from the view of the package manager. Making it both wasteful (both disk space and compile time) and more opaque when it comes to debugging dependency related issues.

This option will allow the best of both worlds. If you are building this without a package manager, you can leave it off. But if you are packaging this up for a package manager, you can enable this and leave the dependencies for the package manager.

Needed to change some target names and add/resurrect some Find modules for this to work.