### PR TITLE
Add back Threads::Threads to WetHairCore

### DIFF
--- a/libWetHair/CMakeLists.txt
+++ b/libWetHair/CMakeLists.txt
@@ -2,6 +2,9 @@
 include (eigen)
 include (onetbb)
 
+set (THREADS_PREFER_PTHREAD_FLAG ON)
+find_package (Threads REQUIRED)
+
 add_library (WetHairCore
   "DER/Dependencies/DegreesOfFreedom.cpp"
   "DER/Dependencies/ElasticStrandUtils.cpp"
@@ -54,7 +57,8 @@ target_include_directories(WetHairCore PUBLIC
 target_link_libraries(WetHairCore
   PUBLIC
   Eigen3::Eigen
-  TBB::tbb)
+  TBB::tbb
+  Threads::Threads)
 
 install(TARGETS WetHairCore
   EXPORT WetHairCore)


### PR DESCRIPTION
Which fixes a linking issue when compiling on GNU/linux. The thread library is separate from the standard library on those systems, which require you to explicitly specify that you need to link it. On other platforms, cmake should make this an no-op.