### PR TITLE
Log pressure solve failure to a file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required (VERSION 3.14.0)
 
 project (libWetHair)
 
-set(CMAKE_CXX_STANDARD          11)
+set(CMAKE_CXX_STANDARD          17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS        OFF)
 

--- a/libWetHair/CMakeLists.txt
+++ b/libWetHair/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library (WetHairCore
   "LevelSetForce.cpp"
   "LinearBendingForce.cpp"
   "LinearSpringForce.cpp"
+  "LogUtilities.cpp"
   "MathUtilities.cpp"
   "PolygonalCohesion.cpp"
   "SceneStepper.cpp"

--- a/libWetHair/LogUtilities.cpp
+++ b/libWetHair/LogUtilities.cpp
@@ -1,0 +1,29 @@
+//
+// This file is part of the libWetHair open source project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright 2023 Fredrik Salomonsson
+
+#include "LogUtilities.h"
+
+#include <chrono>
+#include <filesystem>
+#include <sstream>
+#include <string_view>
+
+namespace libwethair {
+
+std::filesystem::path tempLogFile(const std::string_view prefix,
+                                  const char* timestamp_format)
+{
+  const auto now =
+    std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+
+  std::stringstream name;
+  name << prefix << std::put_time(std::localtime(&now), timestamp_format) << ".log";
+  return std::filesystem::temp_directory_path() / name.str();
+}
+}  // namespace libwethair

--- a/libWetHair/LogUtilities.h
+++ b/libWetHair/LogUtilities.h
@@ -1,0 +1,27 @@
+//
+// This file is part of the libWetHair open source project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright 2023 Fredrik Salomonsson
+
+#ifndef LIBWETHAIR_CORE_LOG_UTILITIES_H_
+#define LIBWETHAIR_CORE_LOG_UTILITIES_H_
+
+#include <filesystem>
+#include <string_view>
+
+namespace libwethair {
+
+/// Generate a path to a file in the temp directory.
+///
+/// The path will be <temp directory>/<prefix><timestamp>.log
+std::filesystem::path tempLogFile(const std::string_view prefix,
+                                  const char* timestamp_format = "%Y%m%dT%H%M%S");
+
+}  // namespace libwethair
+
+#endif  // LIBWETHAIR_CORE_LOG_UTILITIES_H_
+

--- a/libWetHair/LogUtilities.h
+++ b/libWetHair/LogUtilities.h
@@ -11,6 +11,9 @@
 #define LIBWETHAIR_CORE_LOG_UTILITIES_H_
 
 #include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <ostream>
 #include <string_view>
 
 namespace libwethair {
@@ -20,6 +23,29 @@ namespace libwethair {
 /// The path will be <temp directory>/<prefix><timestamp>.log
 std::filesystem::path tempLogFile(const std::string_view prefix,
                                   const char* timestamp_format = "%Y%m%dT%H%M%S");
+
+/// Call write with either an std::ostream of path or stream.
+///
+/// Where the interface for write is:
+///
+///   void write(std::ostream&)
+///
+/// It will try to open the file pointed to by path and pass that to
+/// write. If it succeeds it will write a message to stream containing
+/// the path name. If it fails to open path it will pass stream to
+/// write instead.
+template<typename Writer>
+void delegateLogOutput(const std::filesystem::path& path,
+                       const Writer& write,
+                       std::ostream& stream = std::cerr)
+{
+  if (std::ofstream log(path); log.is_open()) {
+    write(log);
+    stream << "Saved log to: " << path <<"\n";
+  } else {
+    write(stream);
+  }
+}
 
 }  // namespace libwethair
 

--- a/libWetHair/fluidsim2D.cpp
+++ b/libWetHair/fluidsim2D.cpp
@@ -16,6 +16,7 @@
 
 #include "FluidDragForce.h"
 #include "MathUtilities.h"
+#include "LogUtilities.h"
 #include "ThreadUtils.h"
 #include "TwoDScene.h"
 #include "array2_utils.h"
@@ -1502,47 +1503,50 @@ void FluidSim2D::solve_pressure(scalar dt) {
   int iterations;
   bool success = solver.solve(matrix, rhs, pressure, tolerance, iterations);
   if (!success) {
-    printf(
-        "WARNING: Pressure solve "
-        "failed!************************************************\n");
+    std::cerr <<
+      "WARNING: Pressure solve "
+      "failed!************************************************\n";
+    auto write_error_log = [&](std::ostream& out) {
+      out << "rhs=[";
+      for (scalar s : rhs) {
+        out << s << "; ";
+      }
+      out << "];" << std::endl;
 
-    std::cout << "rhs=[";
-    for (scalar s : rhs) {
-      std::cout << s << "; ";
-    }
-    std::cout << "];" << std::endl;
+      out << "pressure=[";
+      for (scalar s : pressure) {
+        out << s << "; ";
+      }
+      out << "];" << std::endl;
 
-    std::cout << "pressure=[";
-    for (scalar s : pressure) {
-      std::cout << s << "; ";
-    }
-    std::cout << "];" << std::endl;
+      write_matlab_array(out, u, "u");
+      write_matlab_array(out, v, "v");
 
-    write_matlab_array(std::cout, u, "u");
-    write_matlab_array(std::cout, v, "v");
+      write_matlab_array(out, u_hair, "u_hair");
+      write_matlab_array(out, v_hair, "v_hair");
 
-    write_matlab_array(std::cout, u_hair, "u_hair");
-    write_matlab_array(std::cout, v_hair, "v_hair");
+      write_matlab_array(out, u_particle, "u_particle");
+      write_matlab_array(out, v_particle, "v_particle");
 
-    write_matlab_array(std::cout, u_particle, "u_particle");
-    write_matlab_array(std::cout, v_particle, "v_particle");
+      write_matlab_array(out, u_drag, "u_drag");
+      write_matlab_array(out, v_drag, "v_drag");
 
-    write_matlab_array(std::cout, u_drag, "u_drag");
-    write_matlab_array(std::cout, v_drag, "v_drag");
+      write_matlab_array(out, u_weights, "u_weights");
+      write_matlab_array(out, v_weights, "v_weights");
 
-    write_matlab_array(std::cout, u_weights, "u_weights");
-    write_matlab_array(std::cout, v_weights, "v_weights");
+      write_matlab_array(out, u_weight_particle, "u_weight_particle");
+      write_matlab_array(out, v_weight_particle, "v_weight_particle");
 
-    write_matlab_array(std::cout, u_weight_particle, "u_weight_particle");
-    write_matlab_array(std::cout, v_weight_particle, "v_weight_particle");
+      write_matlab_array(out, u_weight_hair, "u_weight_hair");
+      write_matlab_array(out, v_weight_hair, "v_weight_hair");
 
-    write_matlab_array(std::cout, u_weight_hair, "u_weight_hair");
-    write_matlab_array(std::cout, v_weight_hair, "v_weight_hair");
+      write_matlab_array(out, u_weight_total, "u_weight_total");
+      write_matlab_array(out, v_weight_total, "v_weight_total");
 
-    write_matlab_array(std::cout, u_weight_total, "u_weight_total");
-    write_matlab_array(std::cout, v_weight_total, "v_weight_total");
+      write_matlab_array(out, liquid_phi, "liquid_phi");
+    };
 
-    write_matlab_array(std::cout, liquid_phi, "liquid_phi");
+    delegateLogOutput(tempLogFile("libWetHair-fluidsim2D-"), write_error_log);
 
     exit(0);
   }

--- a/libWetHair/fluidsim3D.cpp
+++ b/libWetHair/fluidsim3D.cpp
@@ -11,12 +11,14 @@
 
 #include "fluidsim3D.h"
 
-#include <fstream>
 #include <iomanip>
 #include <numeric>
+#include <sstream>
+#include <ostream>
 
 #include "AlgebraicMultigrid.h"
 #include "FluidDragForce.h"
+#include "LogUtilities.h"
 #include "MathUtilities.h"
 #include "ThreadUtils.h"
 #include "TwoDScene.h"
@@ -1934,51 +1936,55 @@ void FluidSim3D::solve_pressure(scalar dt) {
 #endif
 
   if (!success) {
-    printf(
-        "WARNING: Pressure solve "
-        "failed!************************************************\n");
+    std::cerr <<
+      "WARNING: Pressure solve "
+      "failed!************************************************\n";
 
-    std::cout << "rhs=[";
-    for (scalar s : rhs) {
-      std::cout << s << "; ";
-    }
-    std::cout << "];" << std::endl;
+    auto write_error_log = [&](std::ostream& out) {
+      out << "rhs=[";
+      for (scalar s : rhs) {
+        out << s << "; ";
+      }
+      out << "];\n";
 
-    std::cout << "pressure=[";
-    for (scalar s : pressure) {
-      std::cout << s << "; ";
-    }
-    std::cout << "];" << std::endl;
+      out << "pressure=[";
+      for (scalar s : pressure) {
+        out << s << "; ";
+      }
+      out << "];\n";
 
-    write_matlab_array(std::cout, u, "u");
-    write_matlab_array(std::cout, v, "v");
-    write_matlab_array(std::cout, w, "w");
+      write_matlab_array(out, u, "u");
+      write_matlab_array(out, v, "v");
+      write_matlab_array(out, w, "w");
 
-    write_matlab_array(std::cout, u_solid, "u_solid");
-    write_matlab_array(std::cout, v_solid, "v_solid");
-    write_matlab_array(std::cout, w_solid, "w_solid");
+      write_matlab_array(out, u_solid, "u_solid");
+      write_matlab_array(out, v_solid, "v_solid");
+      write_matlab_array(out, w_solid, "w_solid");
 
-    write_matlab_array(std::cout, u_particle, "u_particle");
-    write_matlab_array(std::cout, v_particle, "v_particle");
-    write_matlab_array(std::cout, w_particle, "w_particle");
+      write_matlab_array(out, u_particle, "u_particle");
+      write_matlab_array(out, v_particle, "v_particle");
+      write_matlab_array(out, w_particle, "w_particle");
 
-    write_matlab_array(std::cout, u_drag, "u_drag");
-    write_matlab_array(std::cout, v_drag, "v_drag");
-    write_matlab_array(std::cout, w_drag, "w_drag");
+      write_matlab_array(out, u_drag, "u_drag");
+      write_matlab_array(out, v_drag, "v_drag");
+      write_matlab_array(out, w_drag, "w_drag");
 
-    write_matlab_array(std::cout, u_weights, "u_weights");
-    write_matlab_array(std::cout, v_weights, "v_weights");
-    write_matlab_array(std::cout, w_weights, "w_weights");
+      write_matlab_array(out, u_weights, "u_weights");
+      write_matlab_array(out, v_weights, "v_weights");
+      write_matlab_array(out, w_weights, "w_weights");
 
-    write_matlab_array(std::cout, u_weight_particle, "u_weight_particle");
-    write_matlab_array(std::cout, v_weight_particle, "v_weight_particle");
-    write_matlab_array(std::cout, w_weight_particle, "w_weight_particle");
+      write_matlab_array(out, u_weight_particle, "u_weight_particle");
+      write_matlab_array(out, v_weight_particle, "v_weight_particle");
+      write_matlab_array(out, w_weight_particle, "w_weight_particle");
 
-    write_matlab_array(std::cout, u_weight_total, "u_weight_total");
-    write_matlab_array(std::cout, v_weight_total, "v_weight_total");
-    write_matlab_array(std::cout, w_weight_total, "w_weight_total");
+      write_matlab_array(out, u_weight_total, "u_weight_total");
+      write_matlab_array(out, v_weight_total, "v_weight_total");
+      write_matlab_array(out, w_weight_total, "w_weight_total");
 
-    write_matlab_array(std::cout, liquid_phi, "liquid_phi");
+      write_matlab_array(out, liquid_phi, "liquid_phi");
+    };
+
+    delegateLogOutput(tempLogFile("libWetHair-fluidsim3D-"), write_error_log);
 
     exit(0);
   }


### PR DESCRIPTION
Hi

I noticed that when the pressure solver fails, it will dump its state to `std::cout`. If you run a relative large sim that will be a ton of data.

I refactored that to first try to dump the state into a file, if it fails to open the file, then it will dump the data to standard error.

I opted to bump up the C++ standard to C++17 (let me know if you want this in a separate PR) to be able to use `std::filesystem`. As this allows to get the temp directory in a cross platform compatible way.
