### PR TITLE
Throw on pressure failure

### DIFF
--- a/App/main.cpp
+++ b/App/main.cpp
@@ -909,19 +909,29 @@ int main(int argc, char** argv) {
   std::cout << outputmod::startblue << "Description: " << outputmod::endblue
             << g_description << std::endl;
 
-  if (g_rendering_enabled) {
-    while (!glfwWindowShouldClose(g_window)) {
-      idle();
-      display();
-      
-      glfwSwapBuffers(g_window);
-      glfwPollEvents();
+  try {
+    if (g_rendering_enabled) {
+      while (!glfwWindowShouldClose(g_window)) {
+        idle();
+        display();
+
+        glfwSwapBuffers(g_window);
+        glfwPollEvents();
+      }
+
+      glfwDestroyWindow(g_window);
+      g_window = nullptr;
+      glfwTerminate();
+    } else {
+      headlessSimLoop();
     }
-    
-    glfwDestroyWindow(g_window);
-    glfwTerminate();
-  } else {
-    headlessSimLoop();
+  } catch (std::runtime_error& error) {
+    if (g_rendering_enabled && g_window != nullptr) {
+      glfwDestroyWindow(g_window);
+      glfwTerminate();
+    }
+    std::cerr << "ERROR: " << error.what() << std::endl;
+    return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;
 }

--- a/App/main.cpp
+++ b/App/main.cpp
@@ -15,6 +15,7 @@
 
 #include <Eigen/StdVector>
 #include <cmath>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -922,6 +923,5 @@ int main(int argc, char** argv) {
   } else {
     headlessSimLoop();
   }
-
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/libWetHair/fluidsim2D.cpp
+++ b/libWetHair/fluidsim2D.cpp
@@ -1544,7 +1544,7 @@ void FluidSim2D::solve_pressure(scalar dt) {
 
     write_matlab_array(std::cout, liquid_phi, "liquid_phi");
 
-    exit(0);
+    throw std::runtime_error("pressure solve failed");
   }
 
   // Apply the velocity update

--- a/libWetHair/fluidsim3D.cpp
+++ b/libWetHair/fluidsim3D.cpp
@@ -1980,7 +1980,7 @@ void FluidSim3D::solve_pressure(scalar dt) {
 
     write_matlab_array(std::cout, liquid_phi, "liquid_phi");
 
-    exit(0);
+    throw std::runtime_error("pressure solve failed");
   }
 
   threadutils::thread_pool::ParallelFor(


### PR DESCRIPTION
Hi,

Changed the behavior when the pressure solver fails to throw a `std::runtime_error` instead of calling `exit`. This allows programs to recover if they catch the throw instead of abruptly getting killed.

I also update the App to catch the throw and exit gracefully. 