### PR TITLE
Initialize pseudo-random particles and fix distribution for fluidsim2D/3D

### DIFF
--- a/libWetHair/fluidsim2D.cpp
+++ b/libWetHair/fluidsim2D.cpp
@@ -1697,11 +1697,11 @@ void FluidSim2D::init_random_particles(const scalar& rl, const scalar& rr,
 
   for (int i = 0; i < ni; ++i) {
     for (int j = 0; j < nj; ++j) {
-      scalar x = ((scalar)i + 0.5 +
-                  (((scalar)rand() / (scalar)RAND_MAX) * 0.5 - 0.5)) *
+      scalar x = ((scalar)i +
+                  (((scalar)rand() / (scalar)RAND_MAX) - 0.5)) *
                  dx;
-      scalar y = ((scalar)j + 0.5 +
-                  (((scalar)rand() / (scalar)RAND_MAX) * 0.5 - 0.5)) *
+      scalar y = ((scalar)j +
+                  (((scalar)rand() / (scalar)RAND_MAX) - 0.5)) *
                  dx;
       Vector2s pt = Vector2s(x, y) + origin;
       Vector2s vel;

--- a/libWetHair/fluidsim2D.cpp
+++ b/libWetHair/fluidsim2D.cpp
@@ -13,6 +13,7 @@
 
 #include <fstream>
 #include <numeric>
+#include <random>
 
 #include "FluidDragForce.h"
 #include "MathUtilities.h"
@@ -1681,6 +1682,11 @@ void FluidSim2D::init_hair_particles() {
   }
 }
 
+void FluidSim2D::set_particle_seed(const std::size_t seed)
+{
+    particle_seed = seed;
+}
+
 void FluidSim2D::init_random_particles(const scalar& rl, const scalar& rr,
                                        const scalar& rb, const scalar& rt) {
   particles.clear();
@@ -1695,14 +1701,13 @@ void FluidSim2D::init_random_particles(const scalar& rl, const scalar& rr,
   scalar srb = rb * nj * dx;
   scalar srt = rt * nj * dx;
 
+  std::mt19937 generator(particle_seed);
+  std::uniform_real_distribution<scalar> distribution(-0.5, 0.5);
+
   for (int i = 0; i < ni; ++i) {
     for (int j = 0; j < nj; ++j) {
-      scalar x = ((scalar)i +
-                  (((scalar)rand() / (scalar)RAND_MAX) - 0.5)) *
-                 dx;
-      scalar y = ((scalar)j +
-                  (((scalar)rand() / (scalar)RAND_MAX) - 0.5)) *
-                 dx;
+      scalar x = ((scalar)i + distribution(generator)) * dx;
+      scalar y = ((scalar)j + distribution(generator)) * dx;
       Vector2s pt = Vector2s(x, y) + origin;
       Vector2s vel;
       if (compute_phi_vel(pt, vel) > 0 && x >= srl && x <= srr && y >= srb &&

--- a/libWetHair/fluidsim2D.h
+++ b/libWetHair/fluidsim2D.h
@@ -44,6 +44,7 @@ class FluidSim2D : public FluidSim {
 
   virtual void advect_boundary(const scalar& dt);
   virtual void update_boundary();
+  virtual void set_particle_seed(const std::size_t seed);
   virtual void init_random_particles(const scalar& rl, const scalar& rr,
                                      const scalar& rb, const scalar& rt);
   virtual void init_hair_particles();
@@ -288,6 +289,8 @@ class FluidSim2D : public FluidSim {
   std::vector<std::vector<HairParticleBridge<2> > > m_hair_bridge_buffer;
 
   std::vector<int> m_hair_particle_affected;
+
+  std::size_t particle_seed = 665;
 };
 
 }  // namespace libwethair

--- a/libWetHair/fluidsim3D.cpp
+++ b/libWetHair/fluidsim3D.cpp
@@ -15,6 +15,7 @@
 #include <numeric>
 #include <sstream>
 #include <ostream>
+#include <random>
 
 #include "AlgebraicMultigrid.h"
 #include "FluidDragForce.h"
@@ -2151,6 +2152,11 @@ void FluidSim3D::init_hair_particles() {
   }
 }
 
+void FluidSim3D::set_particle_seed(const std::size_t seed)
+{
+    particle_seed = seed;
+}
+
 void FluidSim3D::init_random_particles(const scalar& rl, const scalar& rr,
                                        const scalar& rb, const scalar& rt,
                                        const scalar& rf, const scalar& rk) {
@@ -2169,19 +2175,16 @@ void FluidSim3D::init_random_particles(const scalar& rl, const scalar& rr,
   scalar srf = rf * nk * dx;
   scalar srk = rk * nk * dx;
 
+  std::mt19937 generator(particle_seed);
+  std::uniform_real_distribution<scalar> distribution(-0.5, 0.5);
+
   for (int k = 0; k < nk; ++k) {
     for (int i = 0; i < ni; ++i) {
       for (int j = 0; j < nj; ++j) {
         for (int r = 0; r < default_particle_in_cell(); ++r) {
-          scalar x = ((scalar)i +
-                      (((scalar)rand() / (scalar)RAND_MAX) - 0.5)) *
-                     dx;
-          scalar y = ((scalar)j +
-                      (((scalar)rand() / (scalar)RAND_MAX) - 0.5)) *
-                     dx;
-          scalar z = ((scalar)k +
-                      (((scalar)rand() / (scalar)RAND_MAX) - 0.5)) *
-                     dx;
+          scalar x = ((scalar)i + distribution(generator)) * dx;
+          scalar y = ((scalar)j + distribution(generator)) * dx;
+          scalar z = ((scalar)k + distribution(generator)) * dx;
           Vector3s pt = Vector3s(x, y, z) + origin;
 
           Vector3s vel;

--- a/libWetHair/fluidsim3D.cpp
+++ b/libWetHair/fluidsim3D.cpp
@@ -2173,14 +2173,14 @@ void FluidSim3D::init_random_particles(const scalar& rl, const scalar& rr,
     for (int i = 0; i < ni; ++i) {
       for (int j = 0; j < nj; ++j) {
         for (int r = 0; r < default_particle_in_cell(); ++r) {
-          scalar x = ((scalar)i + 0.5 +
-                      (((scalar)rand() / (scalar)RAND_MAX) * 2.0 - 1.0)) *
+          scalar x = ((scalar)i +
+                      (((scalar)rand() / (scalar)RAND_MAX) - 0.5)) *
                      dx;
-          scalar y = ((scalar)j + 0.5 +
-                      (((scalar)rand() / (scalar)RAND_MAX) * 2.0 - 1.0)) *
+          scalar y = ((scalar)j +
+                      (((scalar)rand() / (scalar)RAND_MAX) - 0.5)) *
                      dx;
-          scalar z = ((scalar)k + 0.5 +
-                      (((scalar)rand() / (scalar)RAND_MAX) * 2.0 - 1.0)) *
+          scalar z = ((scalar)k +
+                      (((scalar)rand() / (scalar)RAND_MAX) - 0.5)) *
                      dx;
           Vector3s pt = Vector3s(x, y, z) + origin;
 

--- a/libWetHair/fluidsim3D.h
+++ b/libWetHair/fluidsim3D.h
@@ -44,6 +44,7 @@ class FluidSim3D : public FluidSim {
 
   virtual void advect_boundary(const scalar& dt);
   virtual void update_boundary();
+  virtual void set_particle_seed(const std::size_t seed);
   virtual void init_random_particles(const scalar& rl, const scalar& rr,
                                      const scalar& rb, const scalar& rt,
                                      const scalar& rf, const scalar& rk);
@@ -286,6 +287,9 @@ class FluidSim3D : public FluidSim {
   std::vector<int> m_hair_particle_affected;
 
   int ryoichi_correction_counter;
+
+  std::size_t particle_seed = 665;
+
 };
 
 }  // namespace libwethair


### PR DESCRIPTION
Hi,

When using `FluidSim3D::init_random_particles` there is no way of setting a seed, which results in the fluid particles being slightly different every time you open a scene. Changed it to using [std::uniform_real_distribution](https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution). The slight caveat that the distribution is now [a, b) instead of [a, b] like before. But the particles are now pseudo-randomly placed but the scenes are reproducible.

While adding this I noticed that the original range was [-0.5, 1.5] for 3D and [0, 0.5] for 2D. To me they should be [-0.5, 0.5] for both. If 0,0,0 for a cell is at its center and not at the origin. If origin then they should be [0, 1].

In this PR I fixed the range for both 2D and 3D to be [-0.5, 0.5) and using a pseudo-random number generator to make them reproducible. The seed you can change with the `set_particle_seed(const size_t seed)` function that is added for both.

