### PR TITLE
Momentum explosion detection

### DIFF
--- a/libWetHair/CylindricalShallowFlow.cpp
+++ b/libWetHair/CylindricalShallowFlow.cpp
@@ -1872,6 +1872,7 @@ void CylindricalShallowFlow<DIM>::updateHairFlowHeight(const scalar& dt) {
         }
       }
     } else if (mum == MUM_MOMENTUM) {
+      const scalar old_v_norm = v.norm();
       for (int i = 0; i < np; ++i) {
         int pidx = HairFlow<DIM>::m_particle_indices[i];
         int idof = HairFlow<DIM>::m_parent->getDof(pidx);
@@ -1922,6 +1923,12 @@ void CylindricalShallowFlow<DIM>::updateHairFlowHeight(const scalar& dt) {
             m(idof + 3) = I * M_PI * HairFlow<DIM>::m_area_v_hair(i);
           }
         }
+      }
+      if (const scalar max_velocity_ratio =
+          HairFlow<DIM>::m_parent->getMaxVelocityRatio();
+          (v.norm() / old_v_norm) >= max_velocity_ratio) {
+          throw std::runtime_error("Unstable momentum update detected, "
+                                   "please increase the reduced liquid substeps.");
       }
     }
   } else {

--- a/libWetHair/TwoDScene.cpp
+++ b/libWetHair/TwoDScene.cpp
@@ -72,7 +72,8 @@ WetHairParameter::WetHairParameter()
       viscous_solve(false),
       apply_coriolis(false),
       mass_update_mode(MUM_MOMENTUM),
-      gravity(0.0, -981.0, 0.0) {}
+      gravity(0.0, -981.0, 0.0),
+      max_velocity_ratio(100.0) {}
 
 template <int DIM>
 TwoDScene<DIM>::TwoDScene(const bool& isMassSpring)
@@ -1945,6 +1946,11 @@ const scalar& TwoDScene<DIM>::getLiquidShell() const {
 template <int DIM>
 scalar& TwoDScene<DIM>::getLiquidShell() {
   return m_parameters.regularizer_shell;
+}
+
+template <int DIM>
+const scalar TwoDScene<DIM>::getMaxVelocityRatio() const {
+  return m_parameters.max_velocity_ratio;
 }
 
 template <int DIM>

--- a/libWetHair/TwoDScene.h
+++ b/libWetHair/TwoDScene.h
@@ -146,6 +146,10 @@ struct WetHairParameter {
   MASS_UPDATE_MODE mass_update_mode;
   Vector3s gravity;
 
+  // The max ratio allowed between the magnitude of the new and old
+  // velocity.  Going over this will cause a runtime exception.
+  scalar max_velocity_ratio;
+
   WetHairParameter();
 };
 
@@ -191,6 +195,8 @@ class TwoDScene {
   const scalar& getLiquidShell() const;
 
   scalar& getLiquidShell();
+
+  const scalar getMaxVelocityRatio() const;
 
   const VectorXs& getHairRestMass() const;
 


### PR DESCRIPTION
Hi,
I traced down one of the instabilities I mentioned in #18, it is caused when it updates the momentum in the `CylindricalShallowFlow`. I don't exactly follow what's going on in that code, the paper is pretty sparse on the details. As I don't fully understand the math I went with the next best thing. Bail out if it detects that the momentum update exploded.

This is done by just simply compare the magnitude ratio of the old and new velocity and if that crosses a threshold, abort the whole simulation by throwing an exception. As continue the sim could result in massive memory consumption.